### PR TITLE
Move IRQ handler to the code segment and reduce polymorphism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.lst
 *.map
 *.sts
+*.sym
 # Finished object
 *.drv


### PR DESCRIPTION
The original MS driver supported different mouse types in a single driver by copying the interrupt handlers and some variable storage to a reserved area of the data segment, to control where they steered the IRQs to more easily.

Another reason they used the data segment was because the interrupt handlers (at least the one for the proper PS/2 interrupt) come in with only CS set. If you can assume CS is the data segment, you can have the IP and do load/stores from it.

This PR untangles the mess and makes it execute from CS, reload DS as needed, moves the variables of `device_int` into the data section, and makes the `mouse.asm` part just call `ps2.asm` functions directly. I find the reduced indirection is a lot simpler, but it does mean the driver will only support VMware style mice. (I don't think a fork/adaptation would be too hard to maintain for other types of hypervisor mice if needed. And if it's merited to support it in a single one, we can just revert this PR.)