### PR TITLE
Wheel mouse support

### DIFF
--- a/ps2.asm
+++ b/ps2.asm
@@ -181,7 +181,7 @@ state_xlate db 0
 
 page
 
-; Fairly dark web shit
+; Function pointers and names for dynamic usage, since we can't externFP USER.
 
 lpPostMessage	dd 0
 lpGetFocus	dd 0
@@ -784,7 +784,6 @@ EnableInts endp
 
 ;----------------------------------------------------------------------------;
 
-; Takes
 cProc vmware_handle_wheel <NEAR,PUBLIC> ; nothing to preserve
 	parmW wheel_dir
 	localV cursor_point, 4 ; two ints for POINT?


### PR DESCRIPTION
This handles wheel events by transmuting them into `WM_VSCROLL` messages.

Specifically, it:

1. Checks the wheel status, if it's worthwhile....
2. Grab functions we need from `USER` at runtime, if needed. We can't link against `USER` as a driver, but we can still call into it. Some of the stock DDK drivers use this trick.
3. Grab the current cursor position.
4. Grab the current `HWND` under the cursor. This is not necessarily top-level; controls are subject to it, which is why I do this instead of getting the current active or focused window. (Active is top-level only, focused may not necessarily be possible.)
5. Send the aforementioned message with whatever direction is called for.

There are some odd issues still, some crashing, some just applications not reacting to sudden scroll events well, some just not bothering to respond at all. We're calling this from an interrupt handler, so we're in for some fun, but [Chen seems to claim it's safe to call from there](https://devblogs.microsoft.com/oldnewthing/20211129-00/?p=105979). These others don't seem to be harming anything either?

The comments and unused code are really rough right now, but I'm still experimenting with this....

Some of the discussion is in dosemu2/dosemu2#1552. I think dosemu would like to take this code or a common approach if it works out.